### PR TITLE
force aot mode to extract class

### DIFF
--- a/src/TailwindClient.ts
+++ b/src/TailwindClient.ts
@@ -30,14 +30,25 @@ export class TailwindClient {
     return getTailwindConfigPath(this.project);
   }
 
-  async requestCompileCss() {
+  getConfig() {
     const configPath = this.getConfigPath();
+
+    return {
+      ...require(configPath),
+
+      // NOTICE: extractClassNames would not work when { mode: "jit" }
+      mode: "aot",
+    };
+  }
+
+  async requestCompileCss() {
     const postcss = this.requirePostCss();
     const tailwindcss = this.requireTailwindCss();
+    const config = this.getConfig();
 
     return Promise.all(
       ["base", "components", "utilities"].map((group) =>
-        postcss([tailwindcss(configPath)]).process(`@tailwind ${group};`, {
+        postcss([tailwindcss(config)]).process(`@tailwind ${group};`, {
           from: undefined,
         })
       )

--- a/src/TailwindErrorChecker.ts
+++ b/src/TailwindErrorChecker.ts
@@ -47,7 +47,7 @@ export class TailwindErrorChecker {
       .toArray()
       .map(({ start, length, messageText }) => ({
         source: "irontail",
-        category: ts.DiagnosticCategory.Error,
+        category: ts.DiagnosticCategory.Warning,
         code: 0,
         file: sourceFile,
         start,


### PR DESCRIPTION
closes: #10 
related: https://github.com/tailwindlabs/tailwindcss-intellisense/pull/296

------

When tailwind.config.js has `mode: 'jit'`, it will fail to extract classes ( I do not know why ). Only we can do is forcing "aot" mode internally to workaround it.

This will emit error for all jit-origin classes like `bg-[#ffffff]`, but it is better than completely stopping to work...

Maybe the DiagnosticCategory should default to warning, instead of error